### PR TITLE
new /get_sir_h_rules end point

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -79,16 +79,17 @@ def get_sir_h_timeframe():
     return jsonify(lists)
 
 # SIR+H model with rules
-# parameters = { parameters:{start_time:xxx, population:xxx, patient0:xxx, ...}
-# rules = [{type: 'change_field', field: 'beta', value: 0.5 },...] }
+# parameters = { parameters: {start_time:xxx, population:xxx, patient0:xxx, ...}
+# rules = { list: [{type: 'change_field', field: 'beta', value: 0.5 },...] }
 @app.route('/get_sir_h_rules', methods=["GET"])
 def get_sir_h_rules():
     request_parameters = json.loads(request.args.get('parameters'))
     request_rules = json.loads(request.args.get('rules'))
 
-    print(request_parameters, request_rules)
-    parameters = extract_from_parameters(request_parameters)
-    rules = extract_from_rules(request_rules)
+    start_time, parameters = extract_from_parameters(
+        frozendict(request_parameters))
+    rules = extract_from_rules(
+        tuple([frozendict(rule) for rule in request_rules['list']]))
 
     lists = cached_run_sir_h(parameters, rules)
     return jsonify(lists)

--- a/server/app.py
+++ b/server/app.py
@@ -5,7 +5,7 @@ from flask import Flask, jsonify, json, request
 from flask_cors import CORS, cross_origin
 
 from models.sir_h.simulator import cached_run_sir_h
-from models.rule import RuleChangeField
+from models.rule import RuleChangeField, RuleForceMove
 from functools import lru_cache
 from frozendict import frozendict
 
@@ -34,6 +34,24 @@ def extract_from_parameters(parameters):
 
 
 @lru_cache(maxsize=128)
+def extract_from_rules(request_rules):
+    rules = []
+    for rule in request_rules:
+        date = rule['date']
+        ruletype = rule['type']
+        if ruletype == 'change_field':
+            field = rule['field']
+            value = rule['value']
+            rules.append(RuleChangeField(date, field, value))
+        elif ruletype == 'force_move':
+            src = rule['src']
+            dest = rule['dest']
+            value = rule['value']
+            rules.append(RuleForceMove(date, src, dest, value))
+    return tuple(rules)
+
+
+@lru_cache(maxsize=128)
 def build_rules_from_parameters(parameters_list):
     rules = []
     for index, parameters_timeframe in enumerate(parameters_list):
@@ -56,6 +74,21 @@ def get_sir_h_timeframe():
 
     rules = build_rules_from_parameters(parameters_list)
     start_time, parameters = extract_from_parameters(parameters_list[0])
+
+    lists = cached_run_sir_h(parameters, rules)
+    return jsonify(lists)
+
+# SIR+H model with rules
+# parameters = { parameters:{start_time:xxx, population:xxx, patient0:xxx, ...}
+# rules = [{type: 'change_field', field: 'beta', value: 0.5 },...] }
+@app.route('/get_sir_h_rules', methods=["GET"])
+def get_sir_h_rules():
+    request_parameters = json.loads(request.args.get('parameters'))
+    request_rules = json.loads(request.args.get('rules'))
+
+    print(request_parameters, request_rules)
+    parameters = extract_from_parameters(request_parameters)
+    rules = extract_from_rules(request_rules)
 
     lists = cached_run_sir_h(parameters, rules)
     return jsonify(lists)

--- a/server/models/rule.py
+++ b/server/models/rule.py
@@ -14,6 +14,9 @@ class RuleChangeField(Rule):
         self._field = field
         self._value = value
 
+    def __repr__(self):
+        return f'ChangeField at t={self._date} {self._field}={self._value}'
+
     def apply(self, state):
         state.change_value(self._field, self._value)
 
@@ -24,6 +27,9 @@ class RuleForceMove(Rule):
         self._src = src
         self._dest = dest
         self._value = value
+
+    def __repr__(self):
+        return f'ForceMove at t={self._date} {self._src}->{self._dest}={self._value}'
 
     def apply(self, state):
         state.force_move(self._src, self._dest, self._value)

--- a/server/models/sir_h/simulator.py
+++ b/server/models/sir_h/simulator.py
@@ -28,7 +28,7 @@ def run_sir_h(parameters, rules, data_chu=dict(), specific_series=None):
 @lru_cache(maxsize=128)
 def cached_run_sir_h(parameters, rules, data_chu=frozendict()):
     """ should be called with hashable parameters, such as frozeidict and tuple"""
-    print(parameters)
+    print(f'parameters={parameters} rules={rules}')
     state = State(parameters)
     lim_time = state.parameter('lim_time')
 

--- a/server/models/sir_h/simulator.py
+++ b/server/models/sir_h/simulator.py
@@ -4,9 +4,25 @@ from functools import lru_cache
 from frozendict import frozendict
 
 
-def run_sir_h(parameters, rules, data_chu=frozendict()):
-    """ can be called with mutable parameters"""
-    return cached_run_sir_h(frozendict(parameters), tuple(rules), frozendict(data_chu))
+def run_sir_h(parameters, rules, data_chu=dict(), specific_series=None):
+    """
+        called by labs
+        can be called with mutable parameters
+        do not use cache
+        specific_series sublist of ['SE', 'R', 'INCUB', 'I', 'IH', 'SM',  'SI', 'SS', 'DC']
+    """
+    state = State(parameters)
+    lim_time = state.parameter('lim_time')
+
+    for i in range(lim_time):
+        apply_rules(state, rules)
+        apply_force_move(state, 'SI', 'SE', data_chu)
+        state.step()
+
+        if specific_series == None:
+            return state.extract_series()
+        else:
+            return state.extract_series(specific_series)
 
 
 @lru_cache(maxsize=128)
@@ -15,13 +31,10 @@ def cached_run_sir_h(parameters, rules, data_chu=frozendict()):
     print(parameters)
     state = State(parameters)
     lim_time = state.parameter('lim_time')
-    # print(state)
 
     for i in range(lim_time):
         apply_rules(state, rules)
         apply_force_move(state, 'SI', 'SE', data_chu)
-
         state.step()
-        # print(state)
 
     return state.extract_series()

--- a/server/models/sir_h/state.py
+++ b/server/models/sir_h/state.py
@@ -176,19 +176,15 @@ class State:
         if self._integer:
             delta = int(delta)
 
-        if delta < 0 and delta > -1 :
+        if delta < 0 and delta > -1:
             delta = 0
         assert delta >= 0
 
         self.move('SE', 'INCUB', delta)
 
-    def extract_series(self):
-        sizes = {'SE': ['SE'], 'R': ['R'], 'INCUB': ['INCUB'], 'I': ['IR', 'IH'],
-                 'SM': ['SM'],  'SI': ['SI'], 'SS': ['SS'], 'DC': ['DC'], }
-        inputs = {'R': ['R'], 'INCUB': ['INCUB'], 'I': ['IR', 'IH'],
+    def extract_series(self, names=['SE', 'R', 'INCUB', 'I', 'IH', 'SM',  'SI', 'SS', 'DC']):
+        series = {'SE': ['SE'], 'R': ['R'], 'INCUB': ['INCUB'], 'I': ['IR', 'IH'],
                   'SM': ['SM'],  'SI': ['SI'], 'SS': ['SS'], 'DC': ['DC'], }
-        outputs = {'SE': ['SE'],  'INCUB': ['INCUB'], 'I': ['IR', 'IH'],
-                   'SM': ['SM'],  'SI': ['SI'], 'SS': ['SS'], }
 
         def positive_or_zero(x):
             return x if x >= 0 else 0
@@ -200,13 +196,11 @@ class State:
             return res
 
         lists = dict()
-        for key in sizes.keys():
+        for key in names:
             lists[key] = sum_lists(
-                [self.box(name).get_size_history()[1:] for name in sizes[key]])
-        for key in inputs.keys():
+                [self.box(name).get_size_history()[1:] for name in series[key]])
             lists['input_' + key] = sum_lists(
-                [self.box(name).get_input_history()[1:] for name in inputs[key]])
-        for key in outputs.keys():
+                [self.box(name).get_input_history()[1:] for name in series[key]])
             lists['output_' + key] = sum_lists(
-                [self.box(name).get_removed_history()[1:] for name in outputs[key]])
+                [self.box(name).get_removed_history()[1:] for name in series[key]])
         return lists

--- a/server/models/sir_h/state.py
+++ b/server/models/sir_h/state.py
@@ -182,7 +182,7 @@ class State:
 
         self.move('SE', 'INCUB', delta)
 
-    def extract_series(self, names=['SE', 'R', 'INCUB', 'I', 'IH', 'SM',  'SI', 'SS', 'DC']):
+    def extract_series(self, names=['SE', 'R', 'INCUB', 'I', 'SM',  'SI', 'SS', 'DC']):
         series = {'SE': ['SE'], 'R': ['R'], 'INCUB': ['INCUB'], 'I': ['IR', 'IH'],
                   'SM': ['SM'],  'SI': ['SI'], 'SS': ['SS'], 'DC': ['DC'], }
 

--- a/src/screens/simulation/Simulation.js
+++ b/src/screens/simulation/Simulation.js
@@ -35,10 +35,13 @@ const getModel = async (timeframes) => {
         params: { parameters: { list: timeframes.filter((timeframe) => timeframe.enabled) } },
     });
 
-    const res = await api.get('/get_sir_h_rules', {
-        params: { parameters: { ...timeframes[0] }, rules: [{ date: 12 }] },
-    });
-    console.log({ res });
+    // example:
+    // const res = await api.get('/get_sir_h_rules', {
+    //     params: {
+    //         parameters: { ...timeframes[0] },
+    //         rules: { list: [{ date: 12, type: 'change_field', field: 'beta', value: 0.5 }] },
+    //     },
+    // });
 
     return data;
 };

--- a/src/screens/simulation/Simulation.js
+++ b/src/screens/simulation/Simulation.js
@@ -35,6 +35,11 @@ const getModel = async (timeframes) => {
         params: { parameters: { list: timeframes.filter((timeframe) => timeframe.enabled) } },
     });
 
+    const res = await api.get('/get_sir_h_rules', {
+        params: { parameters: { ...timeframes[0] }, rules: [{ date: 12 }] },
+    });
+    console.log({ res });
+
     return data;
 };
 


### PR DESCRIPTION
- [x] `run_simulator` function without cache (to be called by labs)
- [x] `run_simulator` can extract specific series (to be more efficient)
- [x] route `/get_sir_h_rules` with 2 parameters : `parameters` and `rules`